### PR TITLE
added website logo as favicon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <meta name="twitter:image" content="">
 
   <!-- Favicons -->
-  <link href="assets/img/favicon.png" rel="icon">
+  <link href="assets/img/logo1.png" rel="icon">
   <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
 
   <!-- Fontawesome  -->


### PR DESCRIPTION
**ISSUE**
 The OSCSA website has a missing favicon image.
![image](https://user-images.githubusercontent.com/54219127/194759798-7b35faaa-61e9-475d-833e-ed3b9fb38476.png)

PR
This PR adds the OSCSA logo as a favicon image for the website.
![image](https://user-images.githubusercontent.com/54219127/194759835-acceddf3-2650-4fa6-8499-8becfe34f1f3.png)
 