### PR TITLE
fix typo error

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
           </div>
         </div>
 
-        <p class="section-description"> Click on individule topics to be directed to a short translated
+        <p class="section-description"> Click on individual topics to be directed to a short translated
           video (< 10 mins) from <a href="https://openlifesci.org/">The Open Life Sciences Program</a>. We continuously aims to improve the translation. If you wish to join the translation working group, don't hesitate to <a
               href="mailto:batool@liverpool.ac.uk">contact us</a>.</p>
       </div>


### PR DESCRIPTION
Issue: 
![image](https://user-images.githubusercontent.com/54219127/194761065-6d44bc59-58a0-4f4c-949d-ce35ab61392e.png)

PR
This PR fixes the typo error in the "Open Science Practices" section, renames "individule" to "individual"