### PR TITLE
Add open education page feature

### DIFF
--- a/ar-index.html
+++ b/ar-index.html
@@ -189,7 +189,7 @@
           </div>
           <div class="col-lg-4 col-md-6 service-item">
             <div class="service-icon-ar"><i class="fas fa-chalkboard-teacher"></i></div>
-            <h4 class="service-title-ar"><a href="https://www.youtube.com/embed/I_5Tn50KCQ4">المصادر التعليمية المفتوحة</a></h4>
+            <h4 class="service-title-ar"><a href="ar-open-educational-ressources.html">المصادر التعليمية المفتوحة</a></h4>
             <p class="service-description-ar">وهي أي مواد تعليمية وبحثية موجودة في المجال العام أو بموجب ترخيص مفتوح. <sup id="fn3">3. [UNESCO]<a href="https://en.unesco.org/themes/building-knowledge-societies/oer" title="UNESCO Webpage.">↩</a></sup>
           </div>
           <div class="col-lg-4 col-md-6 service-item">

--- a/ar-open-educational-ressources.html
+++ b/ar-open-educational-ressources.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NM34VFTB3N"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+
+    gtag('config', 'G-NM34VFTB3N');
+  </script>
+
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title>OSCSA</title>
+  <meta content="" name="description">
+  <meta content="" name="keywords">
+
+  <!-- Facebook Opengraph integration: https://developers.facebook.com/docs/sharing/opengraph -->
+  <meta property="og:title" content="">
+  <meta property="og:image" content="">
+  <meta property="og:url" content="">
+  <meta property="og:site_name" content="">
+  <meta property="og:description" content="">
+
+  <!-- Twitter Cards integration: https://dev.twitter.com/cards/  -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="">
+  <meta name="twitter:title" content="">
+  <meta name="twitter:description" content="">
+  <meta name="twitter:image" content="">
+
+  <!-- Favicons -->
+  <link href="assets/img/favicon.png" rel="icon">
+  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Fontawesome  -->
+  <script src="https://kit.fontawesome.com/fb18aad73b.js" crossorigin="anonymous"></script>
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700,700i|Raleway:300,400,500,700,800" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Arabic:wght@100;200;400&family=Noto+Kufi+Arabic:wght@300&display=swap" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="assets/vendor/aos/aos.css" rel="stylesheet">
+  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!-- Template Main CSS File -->
+  <link href="assets/css/style.css" rel="stylesheet">
+  <link href="assets/css/arabic.css" rel="stylesheet">
+
+
+  <!-- =======================================================
+  * Template Name: Imperial - v5.7.0
+  * Template URL: https://bootstrapmade.com/imperial-free-onepage-bootstrap-theme/
+  * Author: BootstrapMade.com
+  * License: https://bootstrapmade.com/license/
+  ======================================================== -->
+</head>
+
+<body>
+  <!-- ======= Header ======= -->
+  <header id="header" class="d-flex align-items-center">
+    <div class="container d-flex align-items-center justify-content-between">
+
+      <nav id="navbar" class="navbar">
+        <ul>
+          <li><a class="nav-link scrollto active" href="ar-index.html#hero">الرئيسية</a></li>
+          <li><a class="nav-link scrollto" href="ar-index.html#about">من نحن</a></li>
+          <li><a class="nav-link scrollto" href="ar-index.html#services">ماهي العلوم المفتوحة</a></li>
+          <li><a class="nav-link scrollto" href="ar-index.html#testimonials">توصيات اليونسكو</a></li>
+          <li><a class="nav-link scrollto" href="ar-index.html#materilas">نشاطاتنا التعليمية</a></li>
+          <li><a class="nav-link scrollto" href="ar-index.html#contact">تواصل معنا</a></li>
+          <li><a href="index.html"><i class="bi bi-globe"></i>EN </a></li>
+        </ul>
+      </nav><!-- .navbar -->
+
+      <a href="index.html" class="logo mr-auto"><img src="assets/img/landing/logo1.png" alt=""></a>
+      <!-- Uncomment below if you prefer to use a text logo -->
+      <!-- <h1 class="logo mr-auto"><a href="index.html">OSCSA</a></h1> -->
+
+
+    </div>
+  </header><!-- End Header -->
+
+  <main id="main">
+
+    <!-- ======= Open Educational resource main content ======= -->
+    <div id="service-page" class="container">
+      <div  data-aos="fade-up">
+          <h3 class="service-title">افتح وصف المصادر التعليمية</h3>
+          <div class="service-title-divider"></div>
+          <p class="service-description"><strong> الموارد التعليمية (OER) </strong> هي مواد تعليمية وتدريس وبحثية
+            بأي تنسيق ووسيلة موجودة في المجال العام أو تخضع لحقوق الطبع والنشر التي تم إصدارها بموجب ترخيص مفتوح ،
+            التي تسمح بالوصول دون تكلفة وإعادة الاستخدام وإعادة الغرض والتكيف وإعادة التوزيع من قبل الآخرين. 
+            <em><a href="https://www.unesco.org/en/communication-information/open-solutions/open-educational-resources">اقرأ أكثر...</a></em>
+          </p>
+          <div class="m-3">
+            <img class="center" src="https://www.unesco.org/sites/default/files/oer-top-picture_1.jpg" alt="فتح صورة مصدر التعليم">
+          </div>
+      </div>
+
+      <div class="row" data-aos="fade-up" data-aos-delay="200">
+
+      <h3 class="service-video-title">عرض فيديو رائع عن التدريب العادل</h3>
+
+        <div data-aos="fade-up">
+          <div class="ratio ratio-16x9">
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/I_5Tn50KCQ4" title="فيديو تدريب عادل" frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          </div>
+        </div>
+      </div>  
+    </div>
+    <!-- End Open Educational resource main content -->
+
+  </main><!-- End #main -->
+
+  <!-- ======= Footer ======= -->
+  <footer id="footer">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="copyright">
+            Get in touch:
+            <a href=""><i class="bi bi-twitter"></i></a>
+            <a href=""><i class="bi bi-linkedin"></i></a>
+            <a href=""><i class="bi bi-github"></i></a> <br>
+            The website content is licensed CC-BY 4.0. <br>
+            Powered by Imperial Theme from <a href="https://bootstrapmade.com/">BootstrapMade</a><br>
+            If you want to report a problem in the wesbite, please open an issue on <a href="https://github.com/Open-Science-Community-Saudi-Arabia/OSCSA_Website">our GitHub repository</a>.<br>
+          </div>
+          <div class="credits">
+            <!--
+            All the links in the footer should remain intact.
+            You can delete the links only if you purchased the pro version.
+            Licensing information: https://bootstrapmade.com/license/
+            Purchase the pro version with working PHP/AJAX contact form: https://bootstrapmade.com/buy/?theme=Imperial
+          -->
+            <!-- Designed by  -->
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer><!-- End Footer -->
+
+  <div id="preloader"></div>
+  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+
+  <!-- Vendor JS Files -->
+  <script src="assets/vendor/aos/aos.js"></script>
+  <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
+  <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
+  <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
+  <script src="assets/vendor/typed.js/typed.min.js"></script>
+  <script src="assets/vendor/php-email-form/validate.js"></script>
+
+  <!-- Template Main JS File -->
+  <script src="assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -457,7 +457,7 @@ section {
   overflow: hidden;
 }
 
-.section-title {
+.section-title, .service-title{
   font-size: 32px;
   color: #111;
   /* text-transform: uppercase; */
@@ -465,16 +465,16 @@ section {
   font-weight: 700;
 }
 
-.section-description {
+.section-description, .service-description{
   text-align: center;
   margin-bottom: 40px;
 }
 
-.section-description a {
+.section-description a, .service-description a{
   color: #166497;
 }
 
-.section-title-divider {
+.section-title-divider, .service-title-divider{
   width: 50px;
   height: 3px;
   background: #03C4EB;
@@ -1117,4 +1117,41 @@ section {
 
 #contact img {
   padding: 20px
+}
+
+/*--------------------------------------------------------------
+# Service Page
+--------------------------------------------------------------*/
+#service-page {
+  background: linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9)), url("../img/services-bg.jpeg") fixed center center;
+  background-size: cover;
+  padding: 80px 0 60px 0;
+}
+
+#service-page .center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+
+
+#service-page .service-title {
+  margin-left: 80px;
+  font-weight: 700;
+  margin-bottom: 15px;
+  text-transform: uppercase;
+}
+
+#service-page .service-title a {
+  color: #111;
+}
+
+#service-page .service-video-title {
+  font-size: 28px;
+  color: #111;
+  text-align: center;
+  font-weight: 600;
+  margin-bottom: 3rem!important;
+  margin-top: 3rem!important;
 }

--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
           </div>
           <div class="col-lg-4 col-md-6 service-item">
             <div class="service-icon"><i class="fas fa-chalkboard-teacher"></i></div>
-            <h4 class="service-title"><a href="https://www.youtube.com/embed/I_5Tn50KCQ4">Open Educational Resources</a></h4>
+            <h4 class="service-title"><a href="open-educational-ressources.html">Open Educational Resources</a></h4>
             <p class="service-description">They are any learning and research materials that reside in the public domain or under an open license. <sup id="fn3">3. [UNESCO]<a href="https://en.unesco.org/themes/building-knowledge-societies/oer"
                   title="UNESCO Webpage.">↩</a></sup>
           </div>

--- a/open-educational-ressources.html
+++ b/open-educational-ressources.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NM34VFTB3N"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+
+    gtag('config', 'G-NM34VFTB3N');
+  </script>
+
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title>OSCSA</title>
+  <meta content="" name="description">
+  <meta content="" name="keywords">
+
+  <!-- Facebook Opengraph integration: https://developers.facebook.com/docs/sharing/opengraph -->
+  <meta property="og:title" content="">
+  <meta property="og:image" content="">
+  <meta property="og:url" content="">
+  <meta property="og:site_name" content="">
+  <meta property="og:description" content="">
+
+  <!-- Twitter Cards integration: https://dev.twitter.com/cards/  -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="">
+  <meta name="twitter:title" content="">
+  <meta name="twitter:description" content="">
+  <meta name="twitter:image" content="">
+
+  <!-- Favicons -->
+  <link href="assets/img/favicon.png" rel="icon">
+  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Fontawesome  -->
+  <script src="https://kit.fontawesome.com/fb18aad73b.js" crossorigin="anonymous"></script>
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700,700i|Raleway:300,400,500,700,800" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Arabic:wght@100;200;400&family=Noto+Kufi+Arabic:wght@300&display=swap" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="assets/vendor/aos/aos.css" rel="stylesheet">
+  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!-- Template Main CSS File -->
+  <link href="assets/css/style.css" rel="stylesheet">
+  <link href="assets/css/arabic.css" rel="stylesheet">
+
+
+  <!-- =======================================================
+  * Template Name: Imperial - v5.7.0
+  * Template URL: https://bootstrapmade.com/imperial-free-onepage-bootstrap-theme/
+  * Author: BootstrapMade.com
+  * License: https://bootstrapmade.com/license/
+  ======================================================== -->
+</head>
+
+<body>
+  <!-- ======= Header ======= -->
+  <header id="header" class="d-flex align-items-center">
+    <div class="container d-flex align-items-center justify-content-between">
+
+      <a href="index.html" class="logo mr-auto"><img src="assets/img/landing/logo1.png" alt=""></a>
+      <!-- Uncomment below if you prefer to use a text logo -->
+      <!-- <h1 class="logo mr-auto"><a href="index.html">OSCSA</a></h1> -->
+
+      <nav id="navbar" class="navbar">
+        <ul>
+          <li><a class="nav-link scrollto active" href="index.html#hero">Home</a></li>
+          <li><a class="nav-link scrollto" href="index.html#about">About</a></li>
+          <li><a class="nav-link scrollto" href="index.html#services">Open Science</a></li>
+          <li><a class="nav-link scrollto" href="index.html#testimonials">UNESCO Recommendation</a></li>
+          <li><a class="nav-link scrollto" href="index.html#materilas">Materials</a></li>
+          <li><a class="nav-link scrollto" href="index.html#contact">Contact</a></li>
+          <li><a href="ar-index.html">عربي <i class="bi bi-globe"></i></a></li>
+        </ul>
+        <i class="bi bi-list mobile-nav-toggle"></i>
+      </nav><!-- .navbar -->
+
+    </div>
+  </header><!-- End Header -->
+
+  <main id="main">
+
+    <!-- ======= Open Educational resource content ======= -->
+    <section id="service-page">
+      <div class="container">
+        <div  data-aos="fade-up">
+            <h3 class="service-title">Open Educational Resources Description</h3>
+            <div class="service-title-divider"></div>
+            <p class="service-description"><strong> Educational Resources (OER)</strong> are learning, teaching and research materials
+               in any format and medium that reside in the public domain or are under copyright that have been released under an open license, 
+              that permit no-cost access, re-use, re-purpose, adaptation and redistribution by others. 
+              <em><a href="https://www.unesco.org/en/communication-information/open-solutions/open-educational-resources"> read more...</a></em>
+            </p>
+            <div class="m-3">
+              <img class="center" src="https://www.unesco.org/sites/default/files/oer-top-picture_1.jpg" alt="open education resource image">
+            </div>
+        </div>
+
+        <div class="row" data-aos="fade-up" data-aos-delay="200">
+
+        <h3 class="service-video-title">Great Video Presentation About Fair Training</h3>
+
+          <div data-aos="fade-up">
+            <div class="ratio ratio-16x9">
+              <iframe width="560" height="315" src="https://www.youtube.com/embed/I_5Tn50KCQ4" title="Fair Training Video" frameborder="0"
+               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            </div>
+          </div>
+        </div>
+          
+      </div>
+    </section><!-- End Open Educational resource content -->
+
+  </main><!-- End #main -->
+
+  <!-- ======= Footer ======= -->
+  <footer id="footer">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="copyright">
+            Get in touch:
+            <a href=""><i class="bi bi-twitter"></i></a>
+            <a href=""><i class="bi bi-linkedin"></i></a>
+            <a href=""><i class="bi bi-github"></i></a> <br>
+            The website content is licensed CC-BY 4.0. <br>
+            Powered by Imperial Theme from <a href="https://bootstrapmade.com/">BootstrapMade</a><br>
+            If you want to report a problem in the wesbite, please open an issue on <a href="https://github.com/Open-Science-Community-Saudi-Arabia/OSCSA_Website">our GitHub repository</a>.<br>
+          </div>
+          <div class="credits">
+            <!--
+            All the links in the footer should remain intact.
+            You can delete the links only if you purchased the pro version.
+            Licensing information: https://bootstrapmade.com/license/
+            Purchase the pro version with working PHP/AJAX contact form: https://bootstrapmade.com/buy/?theme=Imperial
+          -->
+            <!-- Designed by  -->
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer><!-- End Footer -->
+
+  <div id="preloader"></div>
+  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+
+  <!-- Vendor JS Files -->
+  <script src="assets/vendor/aos/aos.js"></script>
+  <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
+  <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
+  <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
+  <script src="assets/vendor/typed.js/typed.min.js"></script>
+  <script src="assets/vendor/php-email-form/validate.js"></script>
+
+  <!-- Template Main JS File -->
+  <script src="assets/js/main.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
In my current pull request, i worked on the sub-page for Open source bullet point. I worked on `open educational resource` and divide into:

-  Summary of the  `open educational resource`  concept.

- Illustration (image explaining the concept) with alternative tag - you can find any image online!

- The video impeded in iframe.

- Creation of both the Arabic and English pages.

we could have a look of my work on this youtube video of 44 secoonds : [work illustration](https://youtu.be/7--M8xm5i1Y)

For the future work, there is a lot need to be done in the code refactoring. Many components are reuse many times. We could handle the translation more better than creating separate file every time. We could add more languages with less code. There are some aspects of the page which are not really responsive. 
I think I am right candidate for this task.