### PR TITLE
Feature: handle quick contact form with formspree.io - index.html, ar…

### DIFF
--- a/ar-index.html
+++ b/ar-index.html
@@ -479,7 +479,8 @@
           <div class="col-lg-5 col-md-8">
             <div class="form">
               <!-- Replace `form_id` with id generated in formspree.io account -->
-              <form action="https://formspree.io/f/{form_id}"method="post" role="form" class="php-email-form">
+              <form action="https://formspree.io/f/mqkjddaj"method="post" role="form" class="php-email-form">
+
                 <div class="form-group">
                   <input type="text" name="name" class="form-control" id="name" placeholder="Your Name" required>
                 </div>

--- a/ar-index.html
+++ b/ar-index.html
@@ -478,7 +478,8 @@
 
           <div class="col-lg-5 col-md-8">
             <div class="form">
-              <form action="forms/contact.php" method="post" role="form" class="php-email-form">
+              <!-- Replace `form_id` with id generated in formspree.io account -->
+              <form action="https://formspree.io/f/{form_id}"method="post" role="form" class="php-email-form">
                 <div class="form-group">
                   <input type="text" name="name" class="form-control" id="name" placeholder="Your Name" required>
                 </div>

--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@
           <div class="col-lg-5 col-md-8">
             <div class="form">
               <!-- Replace `form_id` with id generated in formspree.io account -->
-              <form action="https://formspree.io/f/{form_id}" method="post" role="form" class="php-email-form">
+              <form action="https://formspree.io/f/mqkjddaj" method="post" role="form" class="php-email-form">
                 <div class="form-group">
                   <input type="text" name="name" class="form-control" id="name" placeholder="Your Name" required>
                 </div>

--- a/index.html
+++ b/index.html
@@ -518,7 +518,8 @@
 
           <div class="col-lg-5 col-md-8">
             <div class="form">
-              <form action="forms/contact.php" method="post" role="form" class="php-email-form">
+              <!-- Replace `form_id` with id generated in formspree.io account -->
+              <form action="https://formspree.io/f/{form_id}" method="post" role="form" class="php-email-form">
                 <div class="form-group">
                   <input type="text" name="name" class="form-control" id="name" placeholder="Your Name" required>
                 </div>


### PR DESCRIPTION
### Summary
Quick contact form for homepage returns error 405 - issue #129 
Email handler for quick contact form exposes sensitive private keys in front end - issue #130  

For this fix, an account should be created on formspree.io to get the form_id to the passed in the form action url (line 522 for index.html, line 481 for ar-index.html)

Fixes #129 #130  #146

*Lorem ipsum dolor sit amet, consectetur adipiscing.*

### List of changes proposed in this PR (pull-request)
* *Added formspree.io as email sending service for quick contact form.*


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Everything looks ok?
